### PR TITLE
Add support for CSS embedded images/imagesheets

### DIFF
--- a/emoji.js
+++ b/emoji.js
@@ -1,6 +1,7 @@
 var emoji = new function(){
 	var self = this;
 	this.img_path = 'emoji/';
+	this.use_css_imgs = false;
 	this.inits = {};
 	this.map = {};
 	this.text_mode = false;
@@ -29,7 +30,11 @@ var emoji = new function(){
 		if (self.replace_mode == 'google'   && self.data[idx][2]) return self.data[idx][2];
 		var img = self.img_path+idx+'.png';
 		var title = self.include_title ? ' title="'+self.data[idx][3][0]+'"' : '';
-		if (self.supports_css) return '<span class="emoji" style="background-image:url('+img+')"'+title+'>:'+self.data[idx][3][0]+':</span>';
+		if (self.supports_css && self.use_css_imgs) {
+			return '<span class="emoji emoji-'+idx+'">:'+self.data[idx][3][0]+':</span>';
+		} else if (self.supports_css) {
+			return '<span class="emoji" style="background-image:url('+img+')"'+title+'>:'+self.data[idx][3][0]+':</span>';
+		}
 		return '<img src="'+img+'" class="emoji" '+title+'/>';
 	};
 	this.init_colons = function(){


### PR DESCRIPTION
When displaying many emoji glyphs, it can be too many HTTP requests to load each glyph as a seperate image file.

This patch allows one to use CSS images loaded via class rules rather than specified inline, which is helpful if you want to do something like use a [CSS sheet generated by emojistatic](http://github.com/mroth/emojistatic) so that you only have a single HTTP request.

To use, specify `emoji.use_css_images = true;` and then as long as you have CSS rules loaded to handle the appropriate class names all is good!

I am using this on a (yet to be released) side project with these changes, figured it would make sense to merge them upstream for others to benefit and also to avoid maintaining a forked version.
