### PR TITLE
Fix browser matching for Mac OSX 10.10 Yosemite

### DIFF
--- a/emoji.js
+++ b/emoji.js
@@ -140,7 +140,7 @@ function emoji(){}
 				return;
 			}
 		}
-		if (ua.match(/Mac OS X 10[._ ][789]/i)){
+		if (ua.match(/Mac OS X 10[._ ](?:[789]|1\d)/i)){
 			if (!ua.match(/Chrome/i)){
 				emoji.replace_mode = 'unified';
 				return;


### PR DESCRIPTION
The regex for unified mode support was only testing up to 10.9, the current release is now 10.10.  The new regex will work up to 10.19, which should last a while.
