### PR TITLE
Add non-encoded emoji filter for add_emoticons

### DIFF
--- a/emoji.js
+++ b/emoji.js
@@ -191,7 +191,8 @@ function emoji(){}
 			if (!emoji.map.colons[emoji.emoticons_data[i]]) continue;
 
 			emoji.map.emoticons[emoticon] = emoji.map.colons[emoji.emoticons_data[i]];
-			a.push(emoji.escape_rx(emoticon));
+			emoji.map.emoticons[i] = emoji.map.colons[emoji.emoticons_data[i]];
+			a.push(emoji.escape_rx(emoticon), emoji.escape_rx(i));
 		}
 		emoji.rx_emoticons = new RegExp(('(^|\\s)('+a.join('|')+')(?=$|[\\s|\\?\\.,!])'), 'g');
 	};


### PR DESCRIPTION
In some cases the input for `add_emoticons()` is not encoded HTML, so the filter should be in both forms.
