### PR TITLE
Allow submodules to work in Travis

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "build/emoji-data"]
 	path = build/emoji-data
-	url = git@github.com:iamcal/emoji-data.git
+	url = https://github.com/iamcal/emoji-data.git


### PR DESCRIPTION
Travis doesn't like the git protocol for submodules. For more, see:

https://docs.travis-ci.com/user/common-build-problems/#Git-cannot-clone-my-Submodules

---

To see an example of this, a broken build example due to this can be seen [here](https://travis-ci.org/jmeas/moolah/builds/134954939).

A semi-fixed build (due to this commit) can be seen [here](https://travis-ci.org/jmeas/moolah/builds/134965545). It's also failing, though, until this lands: https://github.com/iamcal/emoji-data/pull/51

Currently cloning emoji-data to confirm that both commits together fix Travis.

**Update** I can't get Travis configured to pull in both commits, but I'd say I'm 80% sure that these two commits will fix the issue :v: