### PR TITLE
Native emoji on Chrome & Firefox (Mac only)

### DIFF
--- a/build/emoji.js.template
+++ b/build/emoji.js.template
@@ -484,10 +484,8 @@
 				}
 			}
 			if (ua.match(/Mac OS X 10[._ ](?:[789]|1\d)/i)){
-				if (!ua.match(/Chrome/i) && !ua.match(/Firefox/i)){
-					self.replace_mode = 'unified';
-					return;
-				}
+				self.replace_mode = 'unified';
+				return;
 			}
 			if (!self.avoid_ms_emoji){
 				if (ua.match(/Windows NT 6.[1-9]/i) || ua.match(/Windows NT 10.[0-9]/i)){


### PR DESCRIPTION
Fixes #29. Chrome has supported it since 41 & Firefox for even longer.