### PR TITLE
Add option for image tags

### DIFF
--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -390,7 +390,8 @@
 			}else if (self.use_css_imgs){
 				return '<span class="emoji emoji-'+idx+'"'+title+'>'+text+'</span>'+extra;
 			}else if (self.image_mode){
-				return '<img class="emoji emoji-'+idx+'"'+title+' src="'+img+'">'+extra;
+				var unicode = '0x'+idx;
+				return '<img src="'+img+'" class="emoji emoji-'+idx+'" data-unicode="'+String.fromCodePoint(unicode)+'">'+extra; 
 			}else{
 				return '<span class="emoji emoji-sizer" style="background-image:url('+img+')"'+title+'>'+text+'</span>'+extra;
 			}

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -58,6 +58,7 @@
 		 */
 		self.colons_mode = false;
 		self.text_mode = false;
+		self.image_mode = false;
 
 		/**
 		 * If true, sets the "title" property on the span or image that gets
@@ -76,7 +77,7 @@
 		self.allow_native = true;
 
 		/**
-		 * Set to true to use CSS sprites instead of individual images on 
+		 * Set to true to use CSS sprites instead of individual images on
 		 * platforms that support it.
 		 *
 		 * @memberof emoji
@@ -388,6 +389,8 @@
 				return '<span class="emoji-outer emoji-sizer"><span class="emoji-inner" style="'+style+'"'+title+'>'+text+'</span></span>'+extra;
 			}else if (self.use_css_imgs){
 				return '<span class="emoji emoji-'+idx+'"'+title+'>'+text+'</span>'+extra;
+			}else if (self.image_mode){
+				return '<img class="emoji emoji-'+idx+'"'+title+' src="'+img+'">'+extra;
 			}else{
 				return '<span class="emoji emoji-sizer" style="background-image:url('+img+')"'+title+'>'+text+'</span>'+extra;
 			}
@@ -402,13 +405,13 @@
 		if (self.inits.emoticons) return;
 		self.init_colons(); // we require this for the emoticons map
 		self.inits.emoticons = 1;
-		
+
 		var a = [];
 		self.map.emoticons = {};
 		for (var i in self.emoticons_data){
 			// because we never see some characters in our text except as entities, we must do some replacing
 			var emoticon = i.replace(/\&/g, '&amp;').replace(/\</g, '&lt;').replace(/\>/g, '&gt;');
-			
+
 			if (!self.map.colons[self.emoticons_data[i]]) continue;
 
 			self.map.emoticons[emoticon] = self.map.colons[self.emoticons_data[i]];


### PR DESCRIPTION
This PR provides an option to replace emoji's with image tags, instead of only span's. Useful when using js-emoji in content editable areas, as users can click and type within span's containing the replaced emoji background. 