### PR TITLE
Updated a typo where an operator was actually a Bitwise AND assignment.

### DIFF
--- a/build/emoji.js.template
+++ b/build/emoji.js.template
@@ -340,7 +340,7 @@
 		// When not using sheets (which all contain all emoji),
 		// make sure we use an img_set that contains this emoji.
 		// For now, assume set "apple" has all individual images.
-		if ((!self.use_sheet || !self.supports_css) && !(self.data[idx][6] & self.img_sets[self.img_set].mask)) {
+		if ((!self.use_sheet || !self.supports_css) && !(self.data[idx][6] && self.img_sets[self.img_set].mask)) {
 			img_set = 'apple';
 		}
 
@@ -375,7 +375,7 @@
 		//  * we're not using a custom image for self glyph
 		//  * the variation has an image defined for the current image set
 		if (variation_idx && self.variations_data[variation_idx] && self.variations_data[variation_idx][2] && !self.data[idx][7]){
-			if (self.variations_data[variation_idx][2] & self.img_sets[self.img_set].mask){
+			if (self.variations_data[variation_idx][2] && self.img_sets[self.img_set].mask){
 				img = self.img_sets[self.img_set].path+variation_idx+'.png';
 				px = self.variations_data[variation_idx][0];
 				py = self.variations_data[variation_idx][1];


### PR DESCRIPTION
There's a typo on line 343 and 378 where only `&` instead of `&&` is used.

Using `&` does a Bitwise AND operation, and in some edge cases that will return `0`, meaning the if statement never gets entered. This causes an issue in `v2.4.3` of [emoji-data](https://github.com/iamcal/emoji-data/) with the [apple sheet](https://github.com/iamcal/emoji-data/blob/v2.4.3/sheet_apple_64.png) and `:sleuth_or_spy:`.

For example, using `:sleuth_or_spy::skin-tone-3:` results in both `:sleuth_or_spy:` and `:skin-tone-3:` emojis being returned instead of the Inspector Gadget in the specified skin tone.

![:sleuth_or_spy::skin-tone-4:](https://cloud.githubusercontent.com/assets/2965339/18768199/645f2eb8-80d8-11e6-9576-d26e402b5e92.png)

This PR will fix the above but a sad side effect is that for v2.4.3 a blank image is instead returned as there's no skin tone options for `:sleuth_or_spy:`. However, for v.2.4.4 and above things should work as expected. 🎉 