### PR TITLE
Fixes variation data for obsoletes

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -122,7 +122,11 @@
 
 		if (is_array($vars_out[$new_key])){
 			foreach ($vars_out[$new_key] as $k => $v){
-				$vars_out[$new_key][$k][4] = array_unique(array_merge($vars_out[$new_key][$k][4], $vars_out[$old_key][$k][4]));
+				if (!is_array($vars_out[$old_key][$k][4])) {
+					$vars_out[$new_key][$k][4] = $vars_out[$new_key][$k][4];
+				} else {
+					$vars_out[$new_key][$k][4] = array_unique(array_merge($vars_out[$new_key][$k][4], $vars_out[$old_key][$k][4]));
+				}
 			}
 		}
 


### PR DESCRIPTION
I was getting warnings about missing arrays and subsequent missing output data when running this against the latest emoji-data. This fixed it, but maybe there's a root issue somewhere else.