### PR TITLE
Add build options for specifying template and skipping non qualified codepoints

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -1,7 +1,9 @@
 <?php
+	$options = getopt("", array("tpl::", "skip-nq"));
 	error_reporting(E_ALL & ~E_NOTICE);
 
 	$dir = dirname(__FILE__);
+	$tpl = $options['tpl'] ? realpath($options['tpl']) : $dir.'/emoji.js.template';
 	$in = file_get_contents($dir.'/emoji-data/emoji.json');
 	$d = json_decode($in, true);
 
@@ -50,7 +52,7 @@
 				$text_out[$txt] = $row['short_name'];
 			}
 		}
-		if ($row['non_qualified']){
+		if (!isset($options['skip-nq']) && $row['non_qualified']){
 			$out[$key][0][] = calc_bytes($row['non_qualified']);
 		}
 		if (count($row['skin_variations'])){
@@ -177,7 +179,7 @@
 	# output
 	#
 
-	$template = file_get_contents($dir.'/emoji.js.template');
+	$template = file_get_contents($tpl);
 
 	$map = array(
 		'#SHEET-SIZE#'	=> $sheet_size,


### PR DESCRIPTION
I forked the js library for our purposes a while ago, but still use this repo for building and maintaining the data lists. This PR adds two command line options to the build.php script:

* `--tpl=<tpl>` lets you provide a custom emoji.js output template
* `--skip-nq` skips non qualified emoji bytes. This avoids matching plain characters like © as an emoji.