### PR TITLE
fix sheet size

### DIFF
--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -637,7 +637,7 @@
 	emoji.prototype.escape_rx = function(text){
 		return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
 	};
-	emoji.prototype.sheet_size = 51;
+	emoji.prototype.sheet_size = 52;
 	/** @private */
 	emoji.prototype.data = {
 		"0023-fe0f-20e3":[["\u0023\uFE0F\u20E3","\u0023\u20E3"],"\uE210","\uDBBA\uDC2C",["hash"],0,0,7,0],


### PR DESCRIPTION
I'm using the lib with the sheet option and noticed it's actually 52 rather than 51.

This is the demo I tested it with:
```
<!DOCTYPE html>
<html>
<head>
	<title>Emoji translation demo</title>
	<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
	<meta name="viewport" content="width=420, user-scalable=no" />
	<link href="emoji.css" rel="stylesheet" type="text/css" />
</head>
<body>

<div id="rm1"></div>
<div id="out1"></div>

<script src="../lib/emoji.js" type="text/javascript"></script>
<script>

var emoji = new EmojiConvertor();
emoji.img_sets['apple'].sheet = '/sheet_apple_64.png';
emoji.use_sheet = true;
emoji.img_set = 'apple';
emoji.allow_native = false;
emoji.init_env();
document.getElementById('out1').innerHTML = emoji.replace_colons("hello :cool: :smile: world");
</script>
</body>
</html>

```