### PR TITLE
Typo error fixed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ the `emoji.img_set` property. Valid values are:
 * `facebook`
 * `messenger`
 
-This value is the used as a lookup in the `emoji.img_sets` property, which defines
+This value is used as a lookup in the `emoji.img_sets` property, which defines
 each set. By default, it assumes your images are under the path `/emoji-data/`, but
 you can override these values:
 


### PR DESCRIPTION
There is a typo error in the images section. The second line of this section, just above the code snippet is written as, "This value is the used as a lookup in the emoji.img_sets property, which defines each set."

The corrected line could be:
"This value is used as a lookup in the emoji.img_sets property, which defines each set." (Here second 'the' is removed in the line).

Thank you.