### PR TITLE
Fix match error when navigator.product does not exist

### DIFF
--- a/build/emoji.js.template
+++ b/build/emoji.js.template
@@ -601,7 +601,7 @@
 					}
 				}
 			}
-			if (navigator.product.match(/ReactNative/i)){
+			if (/ReactNative/i.test(navigator.product)){
 				self.replace_mode = 'unified';
 				return;
 			}


### PR DESCRIPTION
`navigator.product` is deprecated and does not exist in some env, breaking `navigator.product.match`:

```
Cannot read properties of undefined (reading 'match')
```